### PR TITLE
Make this module more generic AVR109 friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ out.Flasher = function(serialport, options) {
   var that = this;
   this.options = options || {};
   this.sp = serialport;
+  this.signature = this.options.signature || 'LUFACDC';
 
   if (this.options.debug) {
     this.sp.on('data', function(d) {
@@ -76,8 +77,8 @@ out.Flasher.prototype = {
   prepare : function(fn) {
     var that = this;
     this.c('S', function(d) {
-          if (d.toString() !== 'LUFACDC') {
-            fn(new Error('Invalid device signature'));
+          if (d.toString() !== that.signature) {
+            fn(new Error('Invalid device signature; expecting: ' + that.signature + ' received: ' + d.toString()));
           }
         })
         .c('V')
@@ -230,7 +231,7 @@ out.Flasher.prototype = {
   }
 };
 
-out.init = function(serialport, fn) {
-  var flasher = new out.Flasher(serialport);
+out.init = function(serialport, options, fn) {
+  var flasher = new out.Flasher(serialport, options);
   flasher.prepare(fn);
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "intelhex": "0.0.1"
   },
   "devDependencies": {
-    "serialport" : "0.7.5"
+    "serialport" : "1.7.4"
   }
 }


### PR DESCRIPTION
This package works really well with other AVR109 bootloaded chips, so I made a small change to allow different signatures to be passed in for validation at the chip preparation stage ✨

Perhaps also a module name change is up for discussion in future?

I also updated node-serialport as it no longer builds on newer versions of Node.
