### PR TITLE
fix webpack bundle ReferenceError under babel-loader

### DIFF
--- a/chip.avr.avr109.js
+++ b/chip.avr.avr109.js
@@ -218,7 +218,7 @@ out.Flasher.prototype = {
     that.run();
   },
 
-  fuseCheck :  fuseCheck = function(fn) {
+  fuseCheck : function(fn) {
     this.options.debug && console.log('checking fuses');
     // fuse check
     this.c('F')


### PR DESCRIPTION

This syntax cause `ReferenceError: fuseCheck is not defined` under babel-loader.