### PR TITLE
fix: running is not defined when running in strict mode

### DIFF
--- a/chip.avr.avr109.js
+++ b/chip.avr.avr109.js
@@ -55,7 +55,7 @@ out.Flasher.prototype = {
       var cmd = that.cmds.shift();
 
       if (cmd) {
-        running = true;
+        that.running = true;
         that.options.debug && process.stdout.write('Send: ' + cmd.value);
         var response = new Buffer(0);
         var onData = function(d) {


### PR DESCRIPTION
Same issue as mentioned in the https://github.com/jacobrosenthal/js-stk500v1/pull/14